### PR TITLE
Update index.html because of the pending end of ShortLinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,7 +518,7 @@
 			<div id="fullURLPopupSubTitle">Use this URL to share or save this groove</div>
 			<div id="fullURLPopupSubSubTitle">(You can also bookmark this page)</div>
 			<div id="fullURLPopupCheckboxes">
-				<span><label  id="shortURLLabel" class="fullURLPopupCheckboxLabel"><input type="checkbox" id="shortenerCheckbox" onchange="myGrooveWriter.shortenerCheckboxChanged();">Short URL</label></span>
+				<span><label  id="shortURLLabel" class="fullURLPopupCheckboxLabel"><input disabled type="checkbox" id="shortenerCheckbox" onchange="myGrooveWriter.shortenerCheckboxChanged();">Short URL</label></span>
 				<span><label id="embedCodeLabel" class="fullURLPopupCheckboxLabel"><input type="checkbox" id="embedCodeCheckbox" onchange="myGrooveWriter.embedCodeCheckboxChanged();">Embed Code</label></span>
 			</div>
 			<div id="fullURLPopupTextFieldContainer"><input type="text" id="fullURLPopupTextField"></div>


### PR DESCRIPTION
Hello Adar, you've made some nice changes to GrooveScribe! I wanted to make some but I don't have the skills to do such a good job.

This small change and pull request are designed to get your attention above the pending end of [Firebase Dynamic Links](https://firebase.google.com/docs/dynamic-links). 

This means (AFIK) that all existing short links to grooves will stop working. I created an Issue at the repo but no response so far.

Also, unless Lou M. does something there is no easy way to convert short URLs to long URLs. You have to follow each link then copy and paste the long URL from the address window in your browser.  A friend of mine has hundreds of these to convert. 

If you have ideas on how to convert short URLs more quickly before August 25 _and/or_ a new solution to shortlinks, that would be appreciated and I'll be looking for commits!

Cheers
Chris F.