### PR TITLE
CI: make lint/tests/build strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,12 @@ jobs:
             npm install || true
           fi
 
-      - name: Lint (if configured)
-        run: |
-          npm run lint || echo "Lint step skipped or failed (no config)."
+      - name: Lint
+        run: npm run -s lint
 
-      - name: Run tests (if configured)
-        run: |
-          npm test || echo "Test step skipped (jest not configured)."
+      - name: Run tests
+        run: npm test
 
-      - name: Build (if configured)
-        run: |
-          npm run build || echo "Build step skipped."
+      - name: Build
+        run: npm run build
 


### PR DESCRIPTION
This PR tightens the CI workflow:

- Removes continue-on-error on lint/test/build steps
- Makes these steps strict so CI fails when scripts are configured and fail

Note: If scripts are not wired yet, consider adding minimal lint/test setup or temporarily relaxing the job.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author