### PR TITLE
CI fix: remove pablo and abc2svg from npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,8 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "abc2svg": "^1.22.14",
     "jsmidgen": "^0.1.5",
-    "midi-player-js": "^2.0.7",
-    "pablo": "^0.4.1"
+    "midi-player-js": "^2.0.7"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Remove non-existent npm dependencies that were causing CI install failures:

- Remove abc2svg and pablo from package.json dependencies. The project uses bundled js/abc2svg-1.js and js/pablo.min.js instead.

This should unblock CI dependency install. No reviewers requested.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author